### PR TITLE
feat: Squash commits on merge

### DIFF
--- a/pkg/webhook/merge_on_review_approval_and_status_checks.go
+++ b/pkg/webhook/merge_on_review_approval_and_status_checks.go
@@ -163,7 +163,8 @@ func mergePR(issue *github.Issue, owner, repository string, gh *github.Client, c
 	}
 
 	_, _, err = gh.PullRequests.Merge(context.Background(), owner, repository, issue.GetNumber(), "", &github.PullRequestOptions{
-		SHA: commitSHA,
+		SHA:         commitSHA,
+		MergeMethod: "squash",
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to merge pull request %s", issue.GetHTMLURL())


### PR DESCRIPTION
This adds an option to squash the commits contained in the pull request when merging.

See:
https://help.github.com/articles/about-pull-request-merges/
https://godoc.org/github.com/google/go-github/github#PullRequestOptions