### PR TITLE
feat: Made pure-bot configurable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -60,6 +60,12 @@
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
+  version = "0.3.2"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -181,6 +187,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a29120f264d97d47883065d264ee6ac3273581bf2f27aa7affbaf32400ad5635"
+  inputs-digest = "fc6839fed5e61b7a34b9a0d9cd2753807d101b2a912057eb925099b9637d40cf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Flags:
 
 Global Flags:
       --config string     config file (default is $HOME/.pure-bot.yaml)
-      --log-level Level   log level (default info)
+      --debug             switch on debugging
 ```
 
 ## Building
@@ -150,11 +150,67 @@ github:
   # Path to the private key downloaded from the setup
   privateKey: /secrets/private-key
 
-  # Labels automatically to apply when a new issue is created
-  newIssueLabels:
-  - notify/triage
-  - new
+# Default configuration for all repos
+defaults:
+
+  # Label related configuration
+  labels:
+
+    # Label applied when a review is approved.
+    # If this label is given this switches on also the feature
+    # of automerging when a review is aproved
+    approved: "approved"
+
+    # List of labels which can be used to mark a PR as 'work in progress'
+    # In this case no automerging will be performed and a status check
+    # will be set to pending. If this list is not configured, then
+    # this feature is switched off
+    wip:
+    - "status/wip"
+    - "wip"
+    - "do not merge"
+
+    # Label added when a reviewer is explicitely requested. In this case
+    # also a status check "pure-bot/review-requested" is added which
+    # will block until a first review is provided. If no such configuration
+    # is given, this feature is switched # off
+    reviewRequested: "status/review-requested"
+
+    # List of labels to add when a new issue (not PR) is created.
+    newIssues:
+    - "triage"
+
+  # List of patterns which when given in the title of a PR will prevent
+  # automerging and a pure-bot/wip check will fail. Same semantics `labels: wip`
+  # and can be used in addition. If no list is provide no check on the PR
+  # title is performed.
+  wipPatterns:
+  - "do not merge"
+  - "wip"
+
+# Repos specific configuration overriding the defaults explained above
+repos:
+
+  # Repo name is the key of this map
+  syndesis:
+
+    # Overriding defaults. Until know there is not yet a way to _remove_ a config
+    # here.
+    labels:
+      reviewRequested: "status/review-requested"
+      approved: "status/approved"
+      newIssues:
+      - "notif/triage"
+
+  pure-bot-sandbox:
+
+    # You can disable pure-bot alltogether for certain repositories, which might be useful
+    # if you enable pure-bot for a whole organization to be used by new repos
+    # by default
+    disabled: true
 ```
+
+As explained above, certain features are switched on only if the corresponding configuration is given.
 
 ## Testing
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,7 @@ var runCmd = &cobra.Command{
 	Short: "Runs pure-bot",
 	Long:  `Runs pure-bot.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		webhookHandler, err := webhook.NewHTTPHandler(botConfig.Webhook, botConfig.GitHubApp, logger.Named("webhook"))
+		webhookHandler, err := webhook.NewHTTPHandler(botConfig.Webhook, botConfig, logger.Named("webhook"))
 		if err != nil {
 			logger.Fatal("failed to create webhook handler", zap.Error(err))
 		}

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -1,0 +1,24 @@
+webhook:
+  secret: 1221324354554354354353
+github:
+  appId: 1968
+  privateKey: /secrets/private-key
+defaults:
+  labels:
+    approved: "approved"
+    wip:
+    - "status/wip"
+    - "wip"
+    - "do not merge"
+  wipPatterns:
+  - "do not merge"
+  - "wip"
+repos:
+  syndesis:
+    labels:
+      reviewRequested: "status/review-requested"
+      approved: "status/approved"
+      newIssues:
+      - "notif/triage"
+  pure-bot-sandbox:
+    disabled: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,13 +22,21 @@ func NewWithDefaults() Config {
 		},
 		WebhookConfig{},
 		GitHubAppConfig{},
+		RepoConfig{
+			Labels: LabelConfig{
+				Approved: "approved",
+			},
+		},
+		nil,
 	}
 }
 
 type Config struct {
-	HTTP      HTTPConfig      `mapstructure:"http"`
-	Webhook   WebhookConfig   `mapstructure:"webhook"`
-	GitHubApp GitHubAppConfig `mapstructure:"github"`
+	HTTP        HTTPConfig            `mapstructure:"http"`
+	Webhook     WebhookConfig         `mapstructure:"webhook"`
+	GitHubApp   GitHubAppConfig       `mapstructure:"github"`
+	DefaultRepo RepoConfig            `mapstructure:"defaults"`
+	Repos       map[string]RepoConfig `mapstructure:"repos"`
 }
 
 type HTTPConfig struct {
@@ -43,8 +51,19 @@ type WebhookConfig struct {
 }
 
 type GitHubAppConfig struct {
-	AppID                int64    `mapstructure:"appId"`
-	PrivateKeyFile       string   `mapstructure:"privateKey"`
-	ReviewRequestedLabel string   `mapstructure:"reviewRequestedLabel"`
-	NewIssueLabels       []string `mapstructure:"newIssueLabels"`
+	AppID          int64  `mapstructure:"appId"`
+	PrivateKeyFile string `mapstructure:"privateKey"`
+}
+
+type RepoConfig struct {
+	Disabled    bool        `mapstructure:"disabled"`
+	Labels      LabelConfig `mapstructure:"labels"`
+	WipPatterns []string    `mapstructure:"wipPatterns"`
+}
+
+type LabelConfig struct {
+	NewIssues       []string `mapstructure:"newIssues"`
+	Wip             []string `mapstructure:"wip"`
+	ReviewRequested string   `mapstructure:"reviewRequested"`
+	Approved        string   `mapstructure:"approved"`
 }

--- a/pkg/webhook/add_label_on_review_approval.go
+++ b/pkg/webhook/add_label_on_review_approval.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	approvedLabel       = "approved"
 	approvedReviewState = "approved"
 )
 
@@ -36,10 +35,16 @@ func (h *addLabelOnReviewApproval) EventTypesHandled() []string {
 	return []string{"pull_request_review"}
 }
 
-func (h *addLabelOnReviewApproval) HandleEvent(eventObject interface{}, gh *github.Client, config config.GitHubAppConfig, logger *zap.Logger) error {
+func (h *addLabelOnReviewApproval) HandleEvent(eventObject interface{}, gh *github.Client, config config.RepoConfig, logger *zap.Logger) error {
 	event, ok := eventObject.(*github.PullRequestReviewEvent)
 	if !ok {
 		return errors.New("wrong event eventObject type")
+	}
+
+	approvedLabel := config.Labels.Approved
+	// Disabled because not configured
+	if approvedLabel == "" {
+		return nil
 	}
 
 	if strings.ToLower(event.Review.GetState()) != approvedReviewState {

--- a/pkg/webhook/dismiss_review_on_push.go
+++ b/pkg/webhook/dismiss_review_on_push.go
@@ -33,7 +33,7 @@ func (h *dismissReview) EventTypesHandled() []string {
 	return []string{"pull_request"}
 }
 
-func (h *dismissReview) HandleEvent(eventObject interface{}, gh *github.Client, config config.GitHubAppConfig, logger *zap.Logger) error {
+func (h *dismissReview) HandleEvent(eventObject interface{}, gh *github.Client, config config.RepoConfig, logger *zap.Logger) error {
 	event, ok := eventObject.(*github.PullRequestEvent)
 	if !ok {
 		return errors.New("wrong event eventObject type")

--- a/pkg/webhook/failed_status_checks_add_comment.go
+++ b/pkg/webhook/failed_status_checks_add_comment.go
@@ -32,7 +32,7 @@ func (h *failedStatusCheckAddComment) EventTypesHandled() []string {
 	return []string{"status"}
 }
 
-func (h *failedStatusCheckAddComment) HandleEvent(eventObject interface{}, gh *github.Client, config config.GitHubAppConfig, logger *zap.Logger) error {
+func (h *failedStatusCheckAddComment) HandleEvent(eventObject interface{}, gh *github.Client, config config.RepoConfig, logger *zap.Logger) error {
 	event, ok := eventObject.(*github.StatusEvent)
 	if !ok {
 		return errors.New("wrong event eventObject type")

--- a/pkg/webhook/new_issue_label.go
+++ b/pkg/webhook/new_issue_label.go
@@ -16,13 +16,15 @@ func (h *newIssueLabel) EventTypesHandled() []string {
 	return []string{"issues"}
 }
 
-func (h *newIssueLabel) HandleEvent(eventObject interface{}, gh *github.Client, config config.GitHubAppConfig, logger *zap.Logger) error {
+func (h *newIssueLabel) HandleEvent(eventObject interface{}, gh *github.Client, config config.RepoConfig, logger *zap.Logger) error {
 	event, ok := eventObject.(*github.IssuesEvent)
 	if !ok {
 		return errors.New("wrong event eventObject type")
 	}
 
-	if config.NewIssueLabels == nil {
+	labelConfig := config.Labels
+
+	if labelConfig.NewIssues == nil {
 		return nil
 	}
 
@@ -30,6 +32,6 @@ func (h *newIssueLabel) HandleEvent(eventObject interface{}, gh *github.Client, 
 		return nil
 	}
 
-	_, _, err := gh.Issues.AddLabelsToIssue(context.Background(), event.Repo.Owner.GetLogin(), event.Repo.GetName(), event.Issue.GetNumber(), config.NewIssueLabels)
+	_, _, err := gh.Issues.AddLabelsToIssue(context.Background(), event.Repo.Owner.GetLogin(), event.Repo.GetName(), event.Issue.GetNumber(), labelConfig.NewIssues)
 	return err
 }

--- a/pkg/webhook/reviewer_request.go
+++ b/pkg/webhook/reviewer_request.go
@@ -20,10 +20,12 @@ func (h *reviewerRequest) EventTypesHandled() []string {
 	return []string{"pull_request", "pull_request_review"}
 }
 
-func (h *reviewerRequest) HandleEvent(eventObject interface{}, gh *github.Client, config config.GitHubAppConfig, logger *zap.Logger) error {
+func (h *reviewerRequest) HandleEvent(eventObject interface{}, gh *github.Client, config config.RepoConfig, logger *zap.Logger) error {
+
+	labelConfig := config.Labels
 
 	// Only run when label has been configured
-	label := config.ReviewRequestedLabel
+	label := labelConfig.ReviewRequested
 	if label == "" {
 		return nil
 	}
@@ -93,7 +95,7 @@ func updateReviewStatus(pr *github.PullRequest, repo *github.Repository, gh *git
 
 	if !hasLabel(pr, label) {
 		logger.Debug("No review requested", zap.Bool("pass", true))
-		return createContextWithSpecifiedStatus(prReviewContext, successStatus, "OK - No review requested", repo, pr, gh)
+		return createContextWithSpecifiedStatus(prReviewContext, successStatus, "OK - no review requested", repo, pr, gh)
 	}
 
 	reviews, err := listReviews(pr, repo, gh)
@@ -103,11 +105,11 @@ func updateReviewStatus(pr *github.PullRequest, repo *github.Repository, gh *git
 
 	if len(reviews) == 0 {
 		logger.Debug("Review requested but none found", zap.Bool("pass", false))
-		return createContextWithSpecifiedStatus(prReviewContext, pendingStatus, "Pending - Reviews requested but none provided", repo, pr, gh)
+		return createContextWithSpecifiedStatus(prReviewContext, pendingStatus, "Pending - reviews requested but none provided", repo, pr, gh)
 	}
 
 	logger.Debug("Review requested and reviews found", zap.Bool("pass", true), zap.Int("nrReviews", len(reviews)))
-	return createContextWithSpecifiedStatus(prReviewContext, successStatus, "OK - Review requested and at least one provided", repo, pr, gh)
+	return createContextWithSpecifiedStatus(prReviewContext, successStatus, "OK - review requested and at least one provided", repo, pr, gh)
 }
 
 // ==============================================================================================

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -64,26 +64,6 @@ func labelsContainsLabel(labels []*github.Label, label string) bool {
 	return false
 }
 
-func prIsLabelledWithOneOfSpecifiedLabels(pr *github.PullRequest, specifiedLabels []string, repo *github.Repository, gh *github.Client) (bool, error) {
-	labels, _, err := gh.Issues.ListLabelsByIssue(
-		context.Background(),
-		repo.Owner.GetLogin(),
-		repo.GetName(),
-		pr.GetNumber(),
-		nil,
-	)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to list labels for PR %s", pr.GetHTMLURL())
-	}
-
-	for _, label := range specifiedLabels {
-		if labelsContainsLabel(labels, label) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 type commitStatus string
 
 var (


### PR DESCRIPTION
Example:

```yaml
webhook:

  # The secrtet configured in the GitHub App setup
  secret: c0434f32dca456d580917fac08912cd78c53cf07

github:

  # The GitHub App ID
  appId: 1234

  # Path to the private key downloaded from the setup
  privateKey: /secrets/private-key

# Default configuration for all repos
defaults:

  # Label related configuration
  labels:

    # Label applied when a review is approved.
    # If this label is given this switches on also the feature
    # of automerging when a review is aproved
    approved: "approved"

    # List of labels which can be used to mark a PR as 'work in progress'
    # In this case no automerging will be performed and a status check
    # will be set to pending. If this list is not configured, then
    # this feature is switched off
    wip:
    - "status/wip"
    - "wip"
    - "do not merge"

    # Label added when a reviewer is explicitely requested. In this case
    # also a status check "pure-bot/review-requested" is added which
    # will block until a first review is provided. If no such configuration
    # is given, this feature is switched # off
    reviewRequested: "status/review-requested"

    # List of labels to add when a new issue (not PR) is created.
    newIssues:
    - "triage"

  # List of patterns which when given in the title of a PR will prevent
  # automerging and a pure-bot/wip check will fail. Same semantics `labels: wip`
  # and can be used in addition. If no list is provide no check on the PR
  # title is performed.
  wipPatterns:
  - "do not merge"
  - "wip"

# Repos specific configuration overriding the defaults explained above
repos:

  # Repo name is the key of this map
  syndesis:

    # Overriding defaults. Until know there is not yet a way to _remove_ a config
    # here.
    labels:
      reviewRequested: "status/review-requested"
      approved: "status/approved"
      newIssues:
      - "notif/triage"

  pure-bot-sandbox:

    # You can disable pure-bot alltogether for certain repositories, which might be useful
    # if you enable pure-bot for a whole organization to be used by new repos
    # by default
    disabled: true
```
