### PR TITLE
Be less dependent on the order of events

### DIFF
--- a/pkg/webhook/webhook_internal_test.go
+++ b/pkg/webhook/webhook_internal_test.go
@@ -16,14 +16,14 @@ func TestIssueRegex(t *testing.T) {
 	}
 
 	issues = issues[:0]
-	extractIssueNumbers(&issues,"Closed #19, Closed #19, Closing #19")
+	extractIssueNumbers(&issues, "Closed #19, Closed #19, Closing #19")
 	if len(issues) != 3 {
 		t.Error("Invalid number of matches")
 	}
 
 	// single matches
 	issues = issues[:0]
-	extractIssueNumbers(&issues,"Fixes #19")
+	extractIssueNumbers(&issues, "Fixes #19")
 	if len(issues) != 1 {
 		t.Error("Invalid number of matches")
 	}
@@ -34,7 +34,7 @@ func TestIssueRegex(t *testing.T) {
 
 	// multiple matches
 	issues = issues[:0]
-	extractIssueNumbers(&issues,"Fixes #19, Closes #20")
+	extractIssueNumbers(&issues, "Fixes #19, Closes #20")
 
 	if len(issues) != 2 {
 		t.Error("Invalid number of matches")

--- a/pkg/webhook/webhook_internal_test.go
+++ b/pkg/webhook/webhook_internal_test.go
@@ -8,19 +8,22 @@ import (
 func TestIssueRegex(t *testing.T) {
 
 	// key words
+	issues := []string{}
 
-	issues := extractIssueNumbers("Fixes #19, Fixed #19, Fixing #19")
+	extractIssueNumbers(&issues, "Fixes #19, Fixed #19, Fixing #19")
 	if len(issues) != 3 {
 		t.Error("Invalid number of matches")
 	}
 
-	issues = extractIssueNumbers("Closed #19, Closed #19, Closing #19")
+	issues = issues[:0]
+	extractIssueNumbers(&issues,"Closed #19, Closed #19, Closing #19")
 	if len(issues) != 3 {
 		t.Error("Invalid number of matches")
 	}
 
 	// single matches
-	issues = extractIssueNumbers("Fixes #19")
+	issues = issues[:0]
+	extractIssueNumbers(&issues,"Fixes #19")
 	if len(issues) != 1 {
 		t.Error("Invalid number of matches")
 	}
@@ -30,7 +33,8 @@ func TestIssueRegex(t *testing.T) {
 	}
 
 	// multiple matches
-	issues = extractIssueNumbers("Fixes #19, Closes #20")
+	issues = issues[:0]
+	extractIssueNumbers(&issues,"Fixes #19, Closes #20")
 
 	if len(issues) != 2 {
 		t.Error("Invalid number of matches")


### PR DESCRIPTION
There had been some issue with keywords in PR messages. In this case the order of events changed (`pr_closed` vs `issues_closed`) and the bot didn't handle the state transitions correctly. This change should allow the bot to post process transitions triggered by keyword independent of the order of github events delivered to the webhook.