### PR TITLE
Fix for issue 56

### DIFF
--- a/pkg/webhook/board_update.go
+++ b/pkg/webhook/board_update.go
@@ -30,7 +30,7 @@ var postProcessing = make(map[string]column)
 
 var zenHubApi = "https://api.zenhub.io"
 
-var regex = regexp.MustCompile("(?mi)(?:clos(?:e[sd]?|ing)|fix(?:e[sd]|ing))[^\\s]*\\s+#(?P<issue>[0-9]+)")
+var regex = regexp.MustCompile("(?mi)(?:clos(?:e[sd]?|ing)|fix(?:e[sd]|ing))[^\\s]*\\s+(?:#|https://github.com/.+/issues/)(?P<issue>[0-9]+)")
 
 var doneColumn = &column{}
 

--- a/pkg/webhook/webhook_internal_test.go
+++ b/pkg/webhook/webhook_internal_test.go
@@ -1,9 +1,9 @@
 package webhook
 
 import (
+	"strconv"
 	"strings"
 	"testing"
-	"strconv"
 )
 
 func TestIssueRegex(t *testing.T) {

--- a/pkg/webhook/webhook_internal_test.go
+++ b/pkg/webhook/webhook_internal_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"strings"
 	"testing"
+	"strconv"
 )
 
 func TestIssueRegex(t *testing.T) {
@@ -46,6 +47,37 @@ func TestIssueRegex(t *testing.T) {
 
 	if strings.Compare("20", issues[1]) != 0 {
 		t.Error("Invalid value " + issues[1])
+	}
+
+	// issue #56
+
+	s := "Fixes #3803 \r\nFixes #3814 \r\n\r\nNotes: This changes the input and output datashape by using only a subset of the fields of an event"
+
+	issues = issues[:0]
+	extractIssueNumbers(&issues, s)
+
+	if len(issues) != 2 {
+		t.Error("Invalid number of matches: " + strconv.Itoa(len(issues)))
+	}
+
+	if strings.Compare("3803", issues[0]) != 0 {
+		t.Error("Invalid value " + issues[0])
+	}
+
+	if strings.Compare("3814", issues[1]) != 0 {
+		t.Error("Invalid value " + issues[1])
+	}
+
+	s = "Fixes https://github.com/syndesisio/syndesis/issues/3405\r\n\r\nIn the PR review I'd like to understand what the difference is between the deploymentVersion and the version. The deploymentVersion is undefined, but the version contains the correct version. Using that instead fixes the issue but I'm unclear why we have two pieces of data that seem to contain the same information. Maybe I'm missing something, or maybe there is larger issue.\r\n\r\n@gashcrumb, @seanforyou23 maybe one of you can shed a light on this?"
+	issues = issues[:0]
+	extractIssueNumbers(&issues, s)
+
+	if len(issues) != 1 {
+		t.Error("Invalid number of matches: " + strconv.Itoa(len(issues)))
+	}
+
+	if strings.Compare("3405", issues[0]) != 0 {
+		t.Error("Invalid value " + issues[0])
 	}
 
 }


### PR DESCRIPTION
I think the main problem was the regex. It has been extended to identify issues references in the following form as well:

```
Fixes https://github.com/syndesisio/syndesis/issues/3405
```